### PR TITLE
Switch to ObjectIdDicts for dicts of types

### DIFF
--- a/src/CasaCore.jl
+++ b/src/CasaCore.jl
@@ -28,11 +28,6 @@ module Private
     export RecordDesc, addField!
     export Record, nfields
     include("containers.jl")
-
-    function __init__()
-        Base.rehash!(type2str)
-        Base.rehash!(type2enum)
-    end
 end
 
 module Tables

--- a/src/containers.jl
+++ b/src/containers.jl
@@ -31,7 +31,7 @@ function recorddescfinalizer(recorddesc::RecordDesc)
 end
 
 function addField!{T}(recorddesc::RecordDesc,field::ASCIIString,::Type{T})
-    tpenum = type2enum[T]
+    tpenum = type2enum[T]::Int
     ccall(("addRecordDescField",libcasacorewrapper),
           Void,(Ptr{Void},Ptr{Cchar},Cint),
           recorddesc.ptr,pointer(field),tpenum)

--- a/src/conversions.jl
+++ b/src/conversions.jl
@@ -46,9 +46,9 @@ const TpInt64         = 29
 const TpArrayInt64    = 30
 const TpNumberOfTypes = 31
 
-const type2str = Dict{Type,ASCIIString}()
+const type2str = ObjectIdDict()
 const str2type = Dict{ASCIIString,Type}()
-const type2enum = Dict{Type,Int}()
+const type2enum = ObjectIdDict()
 const enum2type = Dict{Int,Type}()
 
 for (T,str,enum) in ((Bool,"boolean",TpBool),


### PR DESCRIPTION
This will hopefully alleviate a segfault during precompilation.

Dicts of types have always behaved strangely during precompilation. The hash of a type changes every time Julia runs, so these dicts needed to be rehashed at run time. However recently I have seen these dicts trigger segfaults (cf JuliaLang/Julia#10613). So I need to stop being lazy and actually use ObjectIdDicts.