### PR TITLE
Use absolute paths instead of relative paths

### DIFF
--- a/deps/build.jl
+++ b/deps/build.jl
@@ -5,13 +5,15 @@ println("Downloading the CasaCore source...")
 version = "1.7.0"
 bz2 = "casacore-$version.tar.bz2"
 url = "ftp://ftp.atnf.csiro.au/pub/software/casacore/$bz2"
+dir = joinpath(depsdir,"downloads")
 
-run(`mkdir -p downloads`)
-run(`curl -o $(joinpath("downloads",bz2)) -L $url`)
-run(`tar -xjf $(joinpath("downloads",bz2)) -C downloads`)
+run(`mkdir -p $dir`)
+run(`curl -o $(joinpath(dir,bz2)) -L $url`)
+run(`tar -xjf $(joinpath(dir,bz2)) -C $dir`)
 
 # Build the CasaCore wrapper
 println("Building the CasaCore wrapper...")
-run(`make -C src`)
-run(`make -C src install`)
+dir = joinpath(depsdir,"src")
+run(`make -C $dir`)
+run(`make -C $dir install`)
 


### PR DESCRIPTION
This helps prevent things from being put in the wrong place (which is what I tried and apparently failed to fix with #26, oops)