### PR TITLE
fix a memory error with getKeyword_string

### DIFF
--- a/deps/src/tables.cpp
+++ b/deps/src/tables.cpp
@@ -116,8 +116,6 @@ extern "C" {
         }
     }
 
-    void done_with_keyword_string(char* string) {delete[] string;}
-
     void putKeyword_string(TableProxy* t, char* column, char* keyword, char* keywordvalue) {
         putKeyword<String>(t,column,keyword,keywordvalue);
     }

--- a/deps/src/tables.cpp
+++ b/deps/src/tables.cpp
@@ -104,9 +104,19 @@ extern "C" {
     void putKeyword_float(  TableProxy* t, char* column, char* keyword,  float value) {return putKeyword<Float>(t,column,keyword,value);}
     void putKeyword_double( TableProxy* t, char* column, char* keyword, double value) {return putKeyword<Double>(t,column,keyword,value);}
 
-    char const* getKeyword_string(TableProxy* t, char* column, char* keyword) {
-        return getKeyword<String>(t,column,keyword).c_str();
+    int getKeyword_string_length(TableProxy* t, char* column, char* keyword) {
+        return getKeyword<String>(t,column,keyword).length();
     }
+
+    void getKeyword_string(TableProxy* t, char* column, char* keyword, char* output) {
+        String str = getKeyword<String>(t,column,keyword);
+        int N = str.length();
+        for (int i = 0; i < N; ++i) {
+            output[i] = str[i];
+        }
+    }
+
+    void done_with_keyword_string(char* string) {delete[] string;}
 
     void putKeyword_string(TableProxy* t, char* column, char* keyword, char* keywordvalue) {
         putKeyword<String>(t,column,keyword,keywordvalue);

--- a/src/tables.jl
+++ b/src/tables.jl
@@ -167,10 +167,15 @@ for T in (Bool,Int32,Float32,Float64)
 end
 
 function getKeyword(table::Table,kw::ASCIIString,::Type{ASCIIString})
-    output = ccall(("getKeyword_string",libcasacorewrapper),
-                   Ptr{Cchar},(Ptr{Void},Ptr{Cchar},Ptr{Cchar}),
-                   table.ptr,pointer(""),pointer(kw))
-    bytestring(output)::ASCIIString
+    N = ccall(("getKeyword_string_length",libcasacorewrapper),
+              Int,(Ptr{Void},Ptr{Cchar},Ptr{Cchar}),
+              table.ptr,pointer(""),pointer(kw))
+    output = Array(Cchar,N)
+    ccall(("getKeyword_string",libcasacorewrapper),
+          Ptr{Cchar},(Ptr{Void},Ptr{Cchar},Ptr{Cchar},Ptr{Cchar}),
+          table.ptr,pointer(""),pointer(kw),pointer(output))
+    chars = [Char(x) for x in output]
+    ascii(chars)
 end
 
 function putKeyword!(table::Table,kw::ASCIIString,value::ASCIIString)
@@ -194,10 +199,15 @@ end
 # Deal with special cases (strings)
 
 function getColumnKeyword(table::Table,column::ASCIIString,kw::ASCIIString,::Type{ASCIIString})
-    output = ccall(("getKeyword_string",libcasacorewrapper),
-                   Ptr{Cchar},(Ptr{Void},Ptr{Cchar},Ptr{Cchar}),
-                   table.ptr,pointer(column),pointer(kw))
-    bytestring(output)::ASCIIString
+    N = ccall(("getKeyword_string_length",libcasacorewrapper),
+              Int,(Ptr{Void},Ptr{Cchar},Ptr{Cchar}),
+              table.ptr,pointer(column),pointer(kw))
+    output = Array(Cchar,N)
+    ccall(("getKeyword_string",libcasacorewrapper),
+          Ptr{Cchar},(Ptr{Void},Ptr{Cchar},Ptr{Cchar},Ptr{Cchar}),
+          table.ptr,pointer(column),pointer(kw),pointer(output))
+    chars = [Char(x) for x in output]
+    ascii(chars)
 end
 
 function getColumnKeyword(table::Table,column::ASCIIString,kw::ASCIIString,::Type{Vector{ASCIIString}})


### PR DESCRIPTION
The problem is that the string was going out of scope. If you're lucky, bytestring runs soon enough to read from the memory before it's overwritten, but this isn't guaranteed.

So now we're much more careful about making sure the string stays in scope until Julia has ownership of the information.