### PR TITLE
more robust computation of column shape

### DIFF
--- a/test/measurement-sets.jl
+++ b/test/measurement-sets.jl
@@ -59,11 +59,17 @@
         path = tempname()*".ms"
         ms = MeasurementSets.create(path)
         Tables.add_rows!(ms, 5)
+
         uvw = randn(3, 5)
         ms["UVW"] = uvw
         @test ms["UVW"] == uvw
         @test_throws CasaCoreTablesError ms["UVW"] = randn(3, 4)
         @test_throws CasaCoreTablesError ms["UVW"] = randn(2, 5)
+
+        weight = randn(Float32, 4, 5)
+        ms["WEIGHT"] = weight
+        @test ms["WEIGHT"] == weight
+
         Tables.delete(ms)
     end
 

--- a/test/measurement-sets.jl
+++ b/test/measurement-sets.jl
@@ -55,5 +55,17 @@
         Tables.delete(ms)
     end
 
+    @testset "reading / writing columns" begin
+        path = tempname()*".ms"
+        ms = MeasurementSets.create(path)
+        Tables.add_rows!(ms, 5)
+        uvw = randn(3, 5)
+        ms["UVW"] = uvw
+        @test ms["UVW"] == uvw
+        @test_throws CasaCoreTablesError ms["UVW"] = randn(3, 4)
+        @test_throws CasaCoreTablesError ms["UVW"] = randn(2, 5)
+        Tables.delete(ms)
+    end
+
 end
 


### PR DESCRIPTION
Here we handle a few more cases that were exposed by #71 

Essentially there are now 4 cases:

1. Scalar column - shape is just the number of rows
2. Fixed shape column - we can use `col.shapeColumn()` to get a sensible answer
3. First cell is defined - we can use the shape of the first cell to get the shape of the column (casacore actually makes this assumption in a number of places as well)
4. First cell is not defined - in this case we will just return the number of rows

That last case is not "bad behavior" as long as the column shape is allowed to change (in which case only the number of rows need to match). So we add some extra logic to deal with that as well.

**Note:** Previously we were handling case 1 and assuming case 3 was "good enough" to handle everything else.